### PR TITLE
IEとiOSでのムービー描画乱れの修正

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -1885,8 +1885,24 @@ var CharacterNameFrame = function (_React$Component7) {
           ),
           _react2.default.createElement(
             'g',
-            { stroke: 'white', strokeWidth: '8', fontFamily: 'sans-serif', fontWeight: 'bold', paintOrder: 'stroke',
-              fill: 'url(#grad)', filter: 'url(#filt)', strokeLinejoin: 'round' },
+            { stroke: 'white', strokeWidth: '8', fontFamily: 'sans-serif', fontWeight: 'bold',
+              fill: 'white', filter: 'url(#filt)', strokeLinejoin: 'round' },
+            _react2.default.createElement(
+              'text',
+              { fontSize: '42px', x: '320px', y: '85px', textAnchor: 'left' },
+              '[',
+              this.props.title,
+              ']'
+            ),
+            _react2.default.createElement(
+              'text',
+              { fontSize: '90px', x: '400px', y: '190px', textAnchor: 'middle' },
+              this.props.name
+            )
+          ),
+          _react2.default.createElement(
+            'g',
+            { fill: 'url(#grad)', fontFamily: 'sans-serif', fontWeight: 'bold' },
             _react2.default.createElement(
               'text',
               { fontSize: '42px', x: '320px', y: '85px', textAnchor: 'left' },

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -1676,12 +1676,12 @@ var MoviePlayer = function (_React$Component6) {
       var time = this.refs.video.currentTime;
       this.ctx.clearRect(0, 0, width, height);
       this.ctx.globalCompositeOperation = 'lighter';
-      // main sign, displayed largely on center
-      this.drawSign(0, 0, this.easeAlpha(time, 4.5, 7.1, 0.7));
-      // pasted character image
-      this.drawCharacter(time);
       // main video
       this.ctx.drawImage(this.refs.video, 0, 0, width, height);
+      // main sign, displayed largely on center
+      this.drawSign(0, 0, this.easeAlpha(time, 4.5, 7.1, 0.7), 1);
+      // pasted character image
+      this.drawCharacter(time);
       // small sign, displayed with the character
       this.drawSign(0, 200, this.easeAlpha(time, 10, 20, 1), 0.5, 'source-over');
       // black sign, displayed for a moment on the whiteout screen

--- a/lib/main.js
+++ b/lib/main.js
@@ -1346,8 +1346,12 @@ class CharacterNameFrame extends React.Component {
               </feMerge>
             </filter>
           </defs>
-          <g stroke="white" strokeWidth="8" fontFamily="sans-serif" fontWeight="bold" paintOrder="stroke"
-             fill="url(#grad)" filter="url(#filt)" strokeLinejoin="round">
+          <g stroke="white" strokeWidth="8" fontFamily="sans-serif" fontWeight="bold"
+             fill="white" filter="url(#filt)" strokeLinejoin="round">
+            <text fontSize="42px" x="320px" y="85px" textAnchor="left">[{this.props.title}]</text>
+            <text fontSize="90px" x="400px" y="190px" textAnchor="middle">{this.props.name}</text>
+          </g>
+          <g fill="url(#grad)" fontFamily="sans-serif" fontWeight="bold">
             <text fontSize="42px" x="320px" y="85px" textAnchor="left">[{this.props.title}]</text>
             <text fontSize="90px" x="400px" y="190px" textAnchor="middle">{this.props.name}</text>
           </g>

--- a/lib/main.js
+++ b/lib/main.js
@@ -1214,12 +1214,12 @@ class MoviePlayer extends React.Component {
     const time = this.refs.video.currentTime;
     this.ctx.clearRect(0, 0, width, height);
     this.ctx.globalCompositeOperation = 'lighter';
-    // main sign, displayed largely on center
-    this.drawSign(0, 0, this.easeAlpha(time, 4.5, 7.1, 0.7));
-    // pasted character image
-    this.drawCharacter(time);
     // main video
     this.ctx.drawImage(this.refs.video, 0, 0, width, height);
+    // main sign, displayed largely on center
+    this.drawSign(0, 0, this.easeAlpha(time, 4.5, 7.1, 0.7), 1);
+    // pasted character image
+    this.drawCharacter(time);
     // small sign, displayed with the character
     this.drawSign(0, 200, this.easeAlpha(time, 10, 20, 1), 0.5, 'source-over');
     // black sign, displayed for a moment on the whiteout screen


### PR DESCRIPTION
- IEでSVG文字の塗りより上にストロークが表示されていた問題（strokeOrder未対応のため）を修正。
- iOSでサインとキャラクタ画像がビデオによって隠されてしまい、これらが見えていなかった問題を修正。
